### PR TITLE
Replace rebuild-search-indices

### DIFF
--- a/providence/user/configuration/configuringProvidence/mainConfiguration/search_indexing.md
+++ b/providence/user/configuration/configuringProvidence/mainConfiguration/search_indexing.md
@@ -572,4 +572,4 @@ reflect the configuration modifications. To update the entire search
 index to reflect the new configuration, rebuild the index using
 \"Rebuild search indices\" web interface under **Manage \> Administrate
 \> Maintenance**; or reindex using the command-line caUtils
-rebuild-search-indices command.
+rebuild-search-index command.


### PR DESCRIPTION
caUtils supports rebuild-search-index ; rebuild-search-indices does not appear to be supported at this time.